### PR TITLE
Enable package validation to track public API compatibility

### DIFF
--- a/src/Pure.RelationalSchema.Random/Pure.RelationalSchema.Random.csproj
+++ b/src/Pure.RelationalSchema.Random/Pure.RelationalSchema.Random.csproj
@@ -5,6 +5,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAotCompatible>true</IsAotCompatible>
+    <EnablePackageValidation>true</EnablePackageValidation>
+    <PackageValidationBaselineVersion>1.1.0</PackageValidationBaselineVersion>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>Pure.RelationalSchema.Random</PackageId>


### PR DESCRIPTION
Closes #86

Add `EnablePackageValidation` and `PackageValidationBaselineVersion` to the project file so that breaking public API changes are detected during build/pack before publishing.